### PR TITLE
Add dat-share-all

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ Tools for hosting Dats, managing sets of Dats, etc.
 - [hypercloud](https://github.com/datprotocol/hypercloud) - p2p + ☁
 - [hashbase](https://github.com/beakerbrowser/hashbase) - hosting for the peer-to-peer web
 - [dat-now](https://github.com/joehand/dat-now) - publish live syncing and versioned websites, files or whatever to `now.sh` instantly
+- [dat-share-all](https://github.com/frando/dat-share-all) - quickly share all dats located in a folder from the command-line
 
 Utilities for `hypercore-archiver`:
 


### PR DESCRIPTION
I recently started working with dat and needed a tool to quickly share multiple dats while developing. Existing solutions are either single-dat (the official cli) or include much more functionality (hashbase, hypercloud). Thus, I created [dat-share-all](https://github.com/frando/dat-share-all), a single command with no configuration to share all dats that are located below the current folder.